### PR TITLE
feat: update htsget-rs blog with additional examples

### DIFF
--- a/content/post/2024-11-27-htsget-rs-ga4gh-demo/2024-11-27-htsget-rs-ga4gh-demo.md
+++ b/content/post/2024-11-27-htsget-rs-ga4gh-demo/2024-11-27-htsget-rs-ga4gh-demo.md
@@ -4,6 +4,7 @@ authors:
   - marko-malenic
   - roman-valls-guimera
 date: "2024-11-27"
+lastmod: "2025-01-20"
 slug: htsget-rs-crypt4gh
 layout: post
 categories:
@@ -20,8 +21,8 @@ summary: "htsget-rs demo up and running at GA4GH"
 
 Welcome to the first [htsget-rs](https://github.com/umccr/htsget-rs) public instance with Crypt4GH support, hosted by GA4GH proper. Let's begin with a simple `curl` command:
 
-```
-% curl "https://htsget.ga4gh-demo.org/reads/service-info"
+```sh
+curl "https://htsget.ga4gh-demo.org/reads/service-info"
 ```
 
 Which should yield the following JSON, please open [a htsget spec](https://samtools.github.io/hts-specs/htsget.html) browser tab on the side while you follow up:
@@ -60,13 +61,13 @@ Which should yield the following JSON, please open [a htsget spec](https://samto
 Developers can now go and test the following endpoints with BAM and other formats ([example files deployed from our htsget-рs data folder](https://github.com/umccr/htsget-rs/tree/main/data)):
 
 ```sh
-% curl "https://htsget.ga4gh-demo.org/reads/htsgetlambdastack-bucket83908e77-0bbbuwy4lrax/bam/htsnexus_test_NA12878"
+curl "https://htsget.ga4gh-demo.org/reads/htsgetlambdastack-bucket83908e77-0bbbuwy4lrax/bam/htsnexus_test_NA12878"
 ```
 
 Check out the Crypt4GH encrypted BAM payload example file:
 
 ```sh
-% curl "https://htsget.ga4gh-demo.org/reads/htsgetlambdastack-bucket83908e77-0bbbuwy4lrax/c4gh/htsnexus_test_NA12878"
+curl "https://htsget.ga4gh-demo.org/reads/htsgetlambdastack-bucket83908e77-0bbbuwy4lrax/c4gh/htsnexus_test_NA12878"
 ```
 
 The payload can be decrypted with the test public/private keypair available on the official htsget-rs repo:
@@ -74,6 +75,75 @@ The payload can be decrypted with the test public/private keypair available on t
 [https://github.com/umccr/htsget-rs/tree/main/data/c4gh](https://github.com/umccr/htsget-rs/tree/main/data/c4gh)
 
 Please read the included `README.md` keygen/encrypt/decrypt walkthrough for more details on how to work with those files.
+
+CRAM files can be queried by specifying `?format=CRAM` on the reads endpoint:
+
+```sh
+curl "https://htsget.ga4gh-demo.org/reads/htsgetlambdastack-bucket83908e77-0bbbuwy4lrax/cram/htsnexus_test_NA12878?format=CRAM"
+```
+
+And the equivalent Crypt4GH encrypted CRAM:
+
+```sh
+curl "https://htsget.ga4gh-demo.org/reads/htsgetlambdastack-bucket83908e77-0bbbuwy4lrax/c4gh/htsnexus_test_NA12878?format=CRAM"
+```
+
+Similar to the `/reads` endpoint, `/variants` is also supported for VCF and BCF files:
+
+```sh
+curl "https://htsget.ga4gh-demo.org/variants/service-info"
+```
+
+For example, to fetch the VCF example file, try:
+
+```sh
+curl "https://htsget.ga4gh-demo.org/variants/htsgetlambdastack-bucket83908e77-0bbbuwy4lrax/vcf/spec-v4.3"
+```
+
+Or, the same Crypt4GH encrypted VCF can be fetched with:
+
+```sh
+curl "https://htsget.ga4gh-demo.org/variants/htsgetlambdastack-bucket83908e77-0bbbuwy4lrax/c4gh/spec-v4.3"
+```
+
+BCF files can be obtained by specifying `?format=BCF` on the variants endpoint. To get the example BCF:
+
+```sh
+curl "https://htsget.ga4gh-demo.org/variants/htsgetlambdastack-bucket83908e77-0bbbuwy4lrax/bcf/sample1-bcbio-cancer?format=BCF"
+```
+
+Or, the Crypt4GH encrypted BCF:
+
+```sh
+curl "https://htsget.ga4gh-demo.org/variants/htsgetlambdastack-bucket83908e77-0bbbuwy4lrax/c4gh/sample1-bcbio-cancer?format=BCF"
+```
+
+All the queries above that fetch data (excluding the service-info endpoint) support parameters which can restrict the
+regions returned.
+
+For example, to query a specific reference name with start and end positions, try:
+
+```sh
+curl "https://htsget.ga4gh-demo.org/reads/htsgetlambdastack-bucket83908e77-0bbbuwy4lrax/bam/htsnexus_test_NA12878?referenceName=1&start=1000&end=2000"
+```
+
+Or, with the variants endpoint:
+
+```sh
+curl "https://htsget.ga4gh-demo.org/variants/htsgetlambdastack-bucket83908e77-0bbbuwy4lrax/vcf/spec-v4.3?referenceName=20&start=0&end=100"
+```
+
+This also works with Crypt4GH files, and it means that only specific regions that match the query will be returned:
+
+```sh
+curl "https://htsget.ga4gh-demo.org/reads/htsgetlambdastack-bucket83908e77-0bbbuwy4lrax/c4gh/htsnexus_test_NA12878?referenceName=1&start=1000&end=2000"
+```
+
+Or, with the Crypt4GH VCF file:
+
+```sh
+curl "https://htsget.ga4gh-demo.org/variants/htsgetlambdastack-bucket83908e77-0bbbuwy4lrax/c4gh/spec-v4.3?referenceName=20&start=0&end=100"
+```
 
 Our hope is that this public endpoint will facilitate much needed client implementations for Crypt4GH decryption, to name a few in no particular order:
 


### PR DESCRIPTION
### Changes
* Adds additional examples for querying Crypt4GH/non-Crypt4GH BAM, CRAM, VCF and BCF files on the reads and variants endpoint.